### PR TITLE
RA-433 Reverting the ui.escapeAttribute from non-string items

### DIFF
--- a/omod/src/main/webapp/pages/forms/extension.gsp
+++ b/omod/src/main/webapp/pages/forms/extension.gsp
@@ -13,8 +13,8 @@
 <h2>${ui.encodeHtmlContent(form.name)} - ${ ui.message("formentryapp.addform") }</h2>
 
 <form method="post" action="${ ui.pageLink("formentryapp", "forms/extension") }">
-<input type="hidden" name="extensionForm.form" value="${ui.escapeAttribute(form.id)}" />
-<input type="hidden" name="extensionForm.id" value="${ui.escapeAttribute(extensionForm.id)}" />
+<input type="hidden" name="extensionForm.form" value="${form.id}" />
+<input type="hidden" name="extensionForm.id" value="${extensionForm.id}" />
 
 <p>
 <label name="extensionForm.formTechnology">${ui.message("formentryapp.formtechnology")}: ${formTechnology}<label>
@@ -24,7 +24,7 @@
 <label name="extensionForm.uiLocation">${ui.message("formentryapp.uilocation")}:
 <% if (extensionForm.id) { %>
 ${ui.message("formentryapp." + extensionForm.uiLocation)}
-<input type="hidden" id="extensionForm.uiLocation" name="extensionForm.uiLocation" value="${ui.escapeAttribute(extensionForm.uiLocation)}" />
+<input type="hidden" id="extensionForm.uiLocation" name="extensionForm.uiLocation" value="${extensionForm.uiLocation}" />
 </label>
 <% } else { %>
 </label>
@@ -67,7 +67,7 @@ ${ui.message("formentryapp." + extensionForm.uiLocation)}
 </p>
 
 <p><label name="extensionForm.order">${ui.message("formentryapp.order")}</label>
-<input type="number" id="extensionForm.order" name="extensionForm.order" value="${ui.escapeAttribute(extensionForm.order)}" required/></p>
+<input type="number" id="extensionForm.order" name="extensionForm.order" value="${extensionForm.order}" required/></p>
 
 <p><label name="extensionForm.showIf">${ui.message("formentryapp.showif")}</label>
 <input type="text" id="extensionForm.showIf" name="extensionForm.showIf" value="${ui.escapeAttribute(extensionForm.showIf)}"/></p>


### PR DESCRIPTION
Reverting the ui.escapeAttribute on non-string items.

Screenshots:

Show If with Quotes based on DOB from 2001:
![image](https://user-images.githubusercontent.com/6067053/32296753-4a84bdd4-bf0a-11e7-8f0c-c4286d41f908.png)

The form name is showing for a patient who is 40 years old:
![image](https://user-images.githubusercontent.com/6067053/32296798-790e87c0-bf0a-11e7-9683-8c66c638a58d.png)

The form name is not showing for a patient who is 5 years old:

![image](https://user-images.githubusercontent.com/6067053/32296930-d1d9b0aa-bf0a-11e7-8e21-efe4341f8d2c.png)
